### PR TITLE
Use Sofa API

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,17 +25,19 @@
   },
   "homepage": "https://github.com/swcarlosrj/SpaceX-Land",
   "dependencies": {
-    "apollo-server": "^2.2.2",
+    "apollo-server-express": "^2.3.1",
+    "express": "^4.16.4",
     "graphql": "^14.0.2",
     "lodash": "^4.17.11",
     "lower-case": "^1.1.4",
     "moment": "^2.23.0",
     "mongodb": "^3.1.10",
-    "sofa-api": "^0.0.1",
+    "sofa-api": "0.0.2",
     "ts-node": "^7.0.1",
     "typescript": "^3.2.1"
   },
   "devDependencies": {
+    "@types/express": "^4.16.0",
     "babel-runtime": "6.26.0",
     "eslint": "5.12.0",
     "eslint-config-airbnb": "17.1.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "apollo-server-express": "^2.3.1",
     "express": "^4.16.4",
     "graphql": "^14.0.2",
+    "graphql-tag": "^2.10.0",
     "lodash": "^4.17.11",
     "lower-case": "^1.1.4",
     "moment": "^2.23.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { ApolloServer } from 'apollo-server-express';
-import sofa from 'sofa-api';
+import sofa, { OpenAPI } from 'sofa-api';
 import schema from './schema';
 import context from './context';
 import { getDB } from './context/db';
@@ -26,16 +26,29 @@ import { getDB } from './context/db';
     app
   });
 
+  const openApi = OpenAPI({
+    schema,
+    info: {
+      title: 'SpaceX Rest API'
+    }
+  });
+
   app.use(
     '/rest',
     sofa({
       schema,
-      context: ctx
+      context: ctx,
+      onRoute(info) {
+        openApi.addRoute(info);
+      }
     })
   );
   app.get('/', (_, res) => {
     res.redirect(graphql.graphqlPath);
   });
+
+  // writes every recorder route
+  openApi.save('./swagger.yml');
 
   app.listen({ port }, () => {
     console.log(`🚀  Server ready http://localhost:${port}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ import { getDB } from './context/db';
     }),
   );
 
-  app.listen({ port: process.env.PORT || 4000 }, () => {
+  app.listen({ port }, () => {
     console.log(`🚀  Server ready http://localhost:${port}`);
   });
 })();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,20 +1,31 @@
-import { ApolloServer } from 'apollo-server';
+import express from 'express';
+import { ApolloServer } from 'apollo-server-express';
 import schema from './schema';
 import context from './context';
 import { getDB } from './context/db';
+
 (async () => {
+  const port = process.env.PORT || 4000;
+  const app = express();
+
   const db = await getDB();
-  const server = new ApolloServer({
+  const ctx = { ...context, db };
+
+  const graphql = new ApolloServer({
     schema,
-    context: { ...context, db },
+    context: ctx,
     engine: {
-      apiKey: process.env.ENGINE_API_KEY
+      apiKey: process.env.ENGINE_API_KEY,
     },
     playground: true,
-    introspection: true
+    introspection: true,
   });
 
-  server.listen({ port: process.env.PORT || 4000 }).then(({ url }) => {
-    console.log(`🚀  Server ready at ${url}`);
+  graphql.applyMiddleware({
+    app,
+  });
+
+  app.listen({ port: process.env.PORT || 4000 }, () => {
+    console.log(`🚀  Server ready http://localhost:${port}`);
   });
 })();

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,23 +16,26 @@ import { getDB } from './context/db';
     schema,
     context: ctx,
     engine: {
-      apiKey: process.env.ENGINE_API_KEY,
+      apiKey: process.env.ENGINE_API_KEY
     },
     playground: true,
-    introspection: true,
+    introspection: true
   });
 
   graphql.applyMiddleware({
-    app,
+    app
   });
 
   app.use(
-    '/api',
+    '/rest',
     sofa({
       schema,
-      context: ctx,
-    }),
+      context: ctx
+    })
   );
+  app.get('/', (_, res) => {
+    res.redirect(graphql.graphqlPath);
+  });
 
   app.listen({ port }, () => {
     console.log(`🚀  Server ready http://localhost:${port}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import express from 'express';
 import { ApolloServer } from 'apollo-server-express';
 import sofa, { OpenAPI } from 'sofa-api';
 import schema from './schema';
-import context from './context';
+import ctx from './context';
 import { getDB } from './context/db';
 
 (async () => {
@@ -10,11 +10,11 @@ import { getDB } from './context/db';
   const app = express();
 
   const db = await getDB();
-  const ctx = { ...context, db };
+  const context = { ...ctx, db };
 
   const graphql = new ApolloServer({
     schema,
-    context: ctx,
+    context,
     engine: {
       apiKey: process.env.ENGINE_API_KEY
     },
@@ -37,12 +37,14 @@ import { getDB } from './context/db';
     '/rest',
     sofa({
       schema,
-      context: ctx,
+      context,
       onRoute(info) {
         openApi.addRoute(info);
       }
     })
   );
+
+  // graphql api by default
   app.get('/', (_, res) => {
     res.redirect(graphql.graphqlPath);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import { ApolloServer } from 'apollo-server-express';
+import sofa from 'sofa-api';
 import schema from './schema';
 import context from './context';
 import { getDB } from './context/db';
@@ -24,6 +25,14 @@ import { getDB } from './context/db';
   graphql.applyMiddleware({
     app,
   });
+
+  app.use(
+    '/api',
+    sofa({
+      schema,
+      context: ctx,
+    }),
+  );
 
   app.listen({ port: process.env.PORT || 4000 }, () => {
     console.log(`🚀  Server ready http://localhost:${port}`);

--- a/src/schema/capsule/typeDefs.ts
+++ b/src/schema/capsule/typeDefs.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server';
+import { gql } from 'apollo-server-express';
 
 const typeDefs = gql`
   extend type Query {

--- a/src/schema/capsule/typeDefs.ts
+++ b/src/schema/capsule/typeDefs.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server-express';
+import gql from 'graphql-tag';
 
 const typeDefs = gql`
   extend type Query {

--- a/src/schema/core/typeDefs.ts
+++ b/src/schema/core/typeDefs.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server';
+import { gql } from 'apollo-server-express';
 
 const typeDefs = gql`
   extend type Query {

--- a/src/schema/core/typeDefs.ts
+++ b/src/schema/core/typeDefs.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server-express';
+import gql from 'graphql-tag';
 
 const typeDefs = gql`
   extend type Query {

--- a/src/schema/dragon/typeDefs.ts
+++ b/src/schema/dragon/typeDefs.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server';
+import { gql } from 'apollo-server-express';
 
 const typeDefs = gql`
   extend type Query {

--- a/src/schema/dragon/typeDefs.ts
+++ b/src/schema/dragon/typeDefs.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server-express';
+import gql from 'graphql-tag';
 
 const typeDefs = gql`
   extend type Query {

--- a/src/schema/global/typeDefs/entryPoints.ts
+++ b/src/schema/global/typeDefs/entryPoints.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server';
+import { gql } from 'apollo-server-express';
 
 export const Query = gql`
   type Query {

--- a/src/schema/global/typeDefs/entryPoints.ts
+++ b/src/schema/global/typeDefs/entryPoints.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server-express';
+import gql from 'graphql-tag';
 
 export const Query = gql`
   type Query {

--- a/src/schema/global/typeDefs/scalars.ts
+++ b/src/schema/global/typeDefs/scalars.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server-express';
+import gql from 'graphql-tag';
 
 const scalars = gql`
   scalar Date

--- a/src/schema/global/typeDefs/scalars.ts
+++ b/src/schema/global/typeDefs/scalars.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server';
+import { gql } from 'apollo-server-express';
 
 const scalars = gql`
   scalar Date

--- a/src/schema/global/typeDefs/spaceX.ts
+++ b/src/schema/global/typeDefs/spaceX.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server';
+import { gql } from 'apollo-server-express';
 
 const spaceX = gql`
   type Force {

--- a/src/schema/global/typeDefs/spaceX.ts
+++ b/src/schema/global/typeDefs/spaceX.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server-express';
+import gql from 'graphql-tag';
 
 const spaceX = gql`
   type Force {

--- a/src/schema/history/typeDefs.ts
+++ b/src/schema/history/typeDefs.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server';
+import { gql } from 'apollo-server-express';
 
 const typeDefs = gql`
   extend type Query {

--- a/src/schema/history/typeDefs.ts
+++ b/src/schema/history/typeDefs.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server-express';
+import gql from 'graphql-tag';
 
 const typeDefs = gql`
   extend type Query {

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -1,4 +1,4 @@
-import { makeExecutableSchema } from 'apollo-server';
+import { makeExecutableSchema } from 'apollo-server-express';
 import typeDefs from './typeDefs';
 import resolvers from './resolvers';
 

--- a/src/schema/landpad/typeDefs.ts
+++ b/src/schema/landpad/typeDefs.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server';
+import { gql } from 'apollo-server-express';
 
 const typeDefs = gql`
   extend type Query {

--- a/src/schema/landpad/typeDefs.ts
+++ b/src/schema/landpad/typeDefs.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server-express';
+import gql from 'graphql-tag';
 
 const typeDefs = gql`
   extend type Query {

--- a/src/schema/launch/typeDefs.ts
+++ b/src/schema/launch/typeDefs.ts
@@ -171,7 +171,7 @@ const typeDefs = gql`
     apoapsis_km: Float
     inclination_deg: Float
     period_min: Float
-    lifespan_years: Int
+    lifespan_years: Float
     epoch: Date
     mean_motion: Float
     raan: Float

--- a/src/schema/launch/typeDefs.ts
+++ b/src/schema/launch/typeDefs.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server';
+import { gql } from 'apollo-server-express';
 
 const typeDefs = gql`
   extend type Query {

--- a/src/schema/launch/typeDefs.ts
+++ b/src/schema/launch/typeDefs.ts
@@ -81,7 +81,7 @@ const typeDefs = gql`
     land_success: Boolean
     landing_intent: Boolean
     landing_type: String
-    landing_vehicle: Boolean
+    landing_vehicle: String
   }
   type LaunchRocketSecondStage {
     block: Int

--- a/src/schema/launch/typeDefs.ts
+++ b/src/schema/launch/typeDefs.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server-express';
+import gql from 'graphql-tag';
 
 const typeDefs = gql`
   extend type Query {

--- a/src/schema/launchpad/typeDefs.ts
+++ b/src/schema/launchpad/typeDefs.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server';
+import { gql } from 'apollo-server-express';
 
 const typeDefs = gql`
   extend type Query {

--- a/src/schema/launchpad/typeDefs.ts
+++ b/src/schema/launchpad/typeDefs.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server-express';
+import gql from 'graphql-tag';
 
 const typeDefs = gql`
   extend type Query {

--- a/src/schema/mission/typeDefs.ts
+++ b/src/schema/mission/typeDefs.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server';
+import { gql } from 'apollo-server-express';
 
 const typeDefs = gql`
   extend type Query {

--- a/src/schema/mission/typeDefs.ts
+++ b/src/schema/mission/typeDefs.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server-express';
+import gql from 'graphql-tag';
 
 const typeDefs = gql`
   extend type Query {

--- a/src/schema/payload/typeDefs.ts
+++ b/src/schema/payload/typeDefs.ts
@@ -26,8 +26,8 @@ const typeDefs = gql`
     nationality: String
     manufacturer: String
     payload_type: String
-    payload_mass_kg: Int
-    payload_mass_lbs: Int
+    payload_mass_kg: Float
+    payload_mass_lbs: Float
     orbit: String
     orbit_params: PayloadOrbitParams
   }
@@ -35,7 +35,7 @@ const typeDefs = gql`
   type PayloadOrbitParams {
     reference_system: String
     regime: String
-    longitude: Int
+    longitude: Float
     lifespan_years: Int
     epoch: Date
     mean_motion: Float

--- a/src/schema/payload/typeDefs.ts
+++ b/src/schema/payload/typeDefs.ts
@@ -36,7 +36,7 @@ const typeDefs = gql`
     reference_system: String
     regime: String
     longitude: Float
-    lifespan_years: Int
+    lifespan_years: Float
     epoch: Date
     mean_motion: Float
     raan: Float
@@ -67,7 +67,7 @@ const typeDefs = gql`
     apoapsis_km: Float
     inclination_deg: Float
     period_min: Float
-    lifespan_years: Int
+    lifespan_years: Float
     epoch: Date
     mean_motion: Float
     raan: Float

--- a/src/schema/payload/typeDefs.ts
+++ b/src/schema/payload/typeDefs.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server';
+import { gql } from 'apollo-server-express';
 
 const typeDefs = gql`
   extend type Query {

--- a/src/schema/payload/typeDefs.ts
+++ b/src/schema/payload/typeDefs.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server-express';
+import gql from 'graphql-tag';
 
 const typeDefs = gql`
   extend type Query {

--- a/src/schema/roaster/typeDefs.ts
+++ b/src/schema/roaster/typeDefs.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server';
+import { gql } from 'apollo-server-express';
 
 const typeDefs = gql`
   extend type Query {

--- a/src/schema/roaster/typeDefs.ts
+++ b/src/schema/roaster/typeDefs.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server-express';
+import gql from 'graphql-tag';
 
 const typeDefs = gql`
   extend type Query {

--- a/src/schema/rocket/typeDefs.ts
+++ b/src/schema/rocket/typeDefs.ts
@@ -76,7 +76,7 @@ const typeDefs = gql`
     propellant_2: String
     thrust_sea_level: Force
     thrust_vacuum: Force
-    thrust_to_weight: Int
+    thrust_to_weight: Float
   }
 
   type RocketLandingLegs {

--- a/src/schema/rocket/typeDefs.ts
+++ b/src/schema/rocket/typeDefs.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server';
+import { gql } from 'apollo-server-express';
 
 const typeDefs = gql`
   extend type Query {

--- a/src/schema/rocket/typeDefs.ts
+++ b/src/schema/rocket/typeDefs.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server-express';
+import gql from 'graphql-tag';
 
 const typeDefs = gql`
   extend type Query {

--- a/src/schema/rocket/typeDefs.ts
+++ b/src/schema/rocket/typeDefs.ts
@@ -20,7 +20,7 @@ const typeDefs = gql`
     height: Distance
     diameter: Distance
     mass: Mass
-    payload_weights: RocketPayloadWeight
+    payload_weights: [RocketPayloadWeight]
     first_stage: RocketFirstStage
     second_stage: RocketSecondStage
     engines: RocketEngines

--- a/src/schema/ship/typeDefs.ts
+++ b/src/schema/ship/typeDefs.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server';
+import { gql } from 'apollo-server-express';
 
 const typeDefs = gql`
   extend type Query {

--- a/src/schema/ship/typeDefs.ts
+++ b/src/schema/ship/typeDefs.ts
@@ -1,4 +1,4 @@
-import { gql } from 'apollo-server-express';
+import gql from 'graphql-tag';
 
 const typeDefs = gql`
   extend type Query {

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -627,7 +627,7 @@ export interface Rocket {
 
   mass?: Maybe<Mass>;
 
-  payload_weights?: Maybe<RocketPayloadWeight>;
+  payload_weights?: Maybe<(Maybe<RocketPayloadWeight>)[]>;
 
   first_stage?: Maybe<RocketFirstStage>;
 
@@ -747,7 +747,7 @@ export interface LaunchRocketFirstStageCore {
 
   landing_type?: Maybe<string>;
 
-  landing_vehicle?: Maybe<boolean>;
+  landing_vehicle?: Maybe<string>;
 }
 
 export interface LaunchRocketSecondStage {
@@ -2888,7 +2888,7 @@ export namespace RocketResolvers {
     mass?: MassResolver<Maybe<Mass>, TypeParent, Context>;
 
     payload_weights?: PayloadWeightsResolver<
-      Maybe<RocketPayloadWeight>,
+      Maybe<(Maybe<RocketPayloadWeight>)[]>,
       TypeParent,
       Context
     >;
@@ -2990,7 +2990,7 @@ export namespace RocketResolvers {
     Context = MyContext
   > = Resolver<R, Parent, Context>;
   export type PayloadWeightsResolver<
-    R = Maybe<RocketPayloadWeight>,
+    R = Maybe<(Maybe<RocketPayloadWeight>)[]>,
     Parent = Rocket,
     Context = MyContext
   > = Resolver<R, Parent, Context>;
@@ -3382,7 +3382,7 @@ export namespace LaunchRocketFirstStageCoreResolvers {
     landing_type?: LandingTypeResolver<Maybe<string>, TypeParent, Context>;
 
     landing_vehicle?: LandingVehicleResolver<
-      Maybe<boolean>,
+      Maybe<string>,
       TypeParent,
       Context
     >;
@@ -3434,7 +3434,7 @@ export namespace LaunchRocketFirstStageCoreResolvers {
     Context = MyContext
   > = Resolver<R, Parent, Context>;
   export type LandingVehicleResolver<
-    R = Maybe<boolean>,
+    R = Maybe<string>,
     Parent = LaunchRocketFirstStageCore,
     Context = MyContext
   > = Resolver<R, Parent, Context>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1844,7 +1844,7 @@ graphql-tag-pluck@0.4.4:
     source-map-support "^0.5.9"
     typescript "^3.2.2"
 
-graphql-tag@2.10.0, graphql-tag@^2.9.2:
+graphql-tag@2.10.0, graphql-tag@^2.10.0, graphql-tag@^2.9.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.0.tgz#87da024be863e357551b2b8700e496ee2d4353ae"
 
@@ -3543,7 +3543,6 @@ snapdragon@^0.8.1:
 sofa-api@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/sofa-api/-/sofa-api-0.0.2.tgz#f7bcde423974163e8bb7423e83b240abdc338637"
-  integrity sha512-he4cJLNpGWMPo+ms9/vimqY/MZKUeVsxuCYSbCcYZpnmv25oLwMlxAO00fzE3nVVqw0scJkNSDxFEYy2j/Jgag==
   dependencies:
     change-case "3.0.2"
     yamljs "0.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -194,7 +194,7 @@
     "@types/node" "*"
     "@types/range-parser" "*"
 
-"@types/express@*", "@types/express@4.16.0":
+"@types/express@*", "@types/express@4.16.0", "@types/express@^4.16.0":
   version "4.16.0"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.16.0.tgz#6d8bc42ccaa6f35cf29a2b7c3333cb47b5a32a19"
   dependencies:
@@ -401,7 +401,7 @@ apollo-server-errors@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/apollo-server-errors/-/apollo-server-errors-2.2.0.tgz#5b452a1d6ff76440eb0f127511dc58031a8f3cb5"
 
-apollo-server-express@2.3.1:
+apollo-server-express@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/apollo-server-express/-/apollo-server-express-2.3.1.tgz#0598e2fa0a0d9e6eb570c0bb6ce65c31810a9c09"
   dependencies:
@@ -421,16 +421,6 @@ apollo-server-express@2.3.1:
 apollo-server-plugin-base@0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/apollo-server-plugin-base/-/apollo-server-plugin-base-0.2.1.tgz#d08c9576f7f11ab6e212f352d482faaa4059a31e"
-
-apollo-server@^2.2.2:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/apollo-server/-/apollo-server-2.3.1.tgz#4d2b6bbb48b44d86076680304705b8b7ae952d37"
-  dependencies:
-    apollo-server-core "2.3.1"
-    apollo-server-express "2.3.1"
-    express "^4.0.0"
-    graphql-subscriptions "^1.0.0"
-    graphql-tools "^4.0.0"
 
 apollo-tracing@0.4.0:
   version "0.4.0"
@@ -1430,7 +1420,7 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-express@^4.0.0:
+express@^4.16.4:
   version "4.16.4"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.4.tgz#fddef61926109e24c515ea97fd2f1bdbf62df12e"
   dependencies:
@@ -3550,9 +3540,10 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-sofa-api@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/sofa-api/-/sofa-api-0.0.1.tgz#601581bbd14ed42533a3edc7d3ca79a624b54ab0"
+sofa-api@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/sofa-api/-/sofa-api-0.0.2.tgz#f7bcde423974163e8bb7423e83b240abdc338637"
+  integrity sha512-he4cJLNpGWMPo+ms9/vimqY/MZKUeVsxuCYSbCcYZpnmv25oLwMlxAO00fzE3nVVqw0scJkNSDxFEYy2j/Jgag==
   dependencies:
     change-case "3.0.2"
     yamljs "0.3.0"


### PR DESCRIPTION
In order to use `express` we need to switch from `apollo-server` to `apollo-server-express`.

Apollo Server uses express by default so there's no difference other than having an access to an app instance.